### PR TITLE
 replit.nix

### DIFF
--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,18 @@
+{ pkgs }: {
+    deps = [
+        pkgs.nodejs
+        pkgs.nodePackages.typescript
+        pkgs.imagemagick
+        pkgs.yarn
+        pkgs.git
+        pkgs.ffmpeg
+        pkgs.neofetch
+        pkgs.libwebp
+        pkgs.speedtest-cli
+        pkgs.wget
+        pkgs.libuuid
+    ];
+      env ={
+    LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [pkgs.libuuid];
+  };
+}


### PR DESCRIPTION
{ pkgs }: {
    deps = [
        pkgs.nodejs
        pkgs.nodePackages.typescript
        pkgs.imagemagick
        pkgs.yarn
        pkgs.git
        pkgs.ffmpeg
        pkgs.neofetch
        pkgs.libwebp
        pkgs.speedtest-cli
        pkgs.wget
        pkgs.libuuid
    ];
      env ={
    LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [pkgs.libuuid];
  };
}